### PR TITLE
Make sure we turn ambient pressure to an int.

### DIFF
--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -139,7 +139,7 @@ class SCD30:
 
     @altitude.setter
     def altitude(self, altitude):
-        self._send_command(_CMD_SET_ALTITUDE_COMPENSATION, altitude)
+        self._send_command(_CMD_SET_ALTITUDE_COMPENSATION, int(altitude))
 
     @property
     def temperature_offset(self):

--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -123,6 +123,7 @@ class SCD30:
 
     @ambient_pressure.setter
     def ambient_pressure(self, pressure_mbar):
+        pressure_mbar = int(pressure_mbar)
         if pressure_mbar != 0 and (pressure_mbar > 1200 or pressure_mbar < 700):
             raise AttributeError("ambient_pressure must be from 700 to 1200 mBar")
         self._send_command(_CMD_CONTINUOUS_MEASUREMENT, pressure_mbar)


### PR DESCRIPTION
I noticed that there was this feature to set the pressure for better results, and since I was using a CLUE, I figured I'd set it on startup. Of course, the BMP280 returns a float, not an int, so I got an error about trying to shift a float. This fixes the error, by turning whatever we're given in the setter of `ambient_pressure` into an int, so you can just:

```python
# Tell it our ambient pressure on startup for best data
scd.ambient_pressure = clue.pressure
```