### PR TITLE
Remove default ASC enable

### DIFF
--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -63,8 +63,6 @@ class SCD30:
 
         # set continuous measurement interval in seconds
         self.measurement_interval = 2
-        # activate automatic self-calibration
-        self.self_calibration_enabled = True
         # trigger continuous measurements with optional ambient pressure compensation
         self.ambient_pressure = ambient_pressure
 


### PR DESCRIPTION
Revert to sensor default, which is Auto-Self Calibration (ASC) disabled. The ASC feature has various requirements the sensor must comply with to work successfully. See:
https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD30_Field_Calibration.pdf
for more information.

So probably best to **not** have this not turned ON by default.