### PR TITLE
Slowdown i2c

### DIFF
--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -28,7 +28,7 @@ Implementation Notes
 """
 
 # imports
-from time import sleep
+import time
 from struct import unpack_from, unpack
 import adafruit_bus_device.i2c_device as i2c_device
 from micropython import const
@@ -107,7 +107,7 @@ class SCD30:
     def reset(self):
         """Perform a soft reset on the sensor, restoring default values"""
         self._send_command(_CMD_SOFT_RESET)
-        sleep(0.1)  # not mentioned by datasheet, but required to avoid IO error
+        time.sleep(0.1)  # not mentioned by datasheet, but required to avoid IO error
 
     @property
     def measurement_interval(self):
@@ -147,7 +147,7 @@ class SCD30:
     def self_calibration_enabled(self, enabled):
         self._send_command(_CMD_AUTOMATIC_SELF_CALIBRATION, enabled)
         if enabled:
-            sleep(0.01)
+            time.sleep(0.01)
 
     @property
     def data_available(self):
@@ -278,6 +278,7 @@ class SCD30:
 
         with self.i2c_device as i2c:
             i2c.write(self._buffer, end=end_byte)
+        time.sleep(0.05) # 3ms min delay
 
     def _read_register(self, reg_addr):
         self._buffer[0] = reg_addr >> 8
@@ -285,6 +286,7 @@ class SCD30:
         with self.i2c_device as i2c:
             i2c.write(self._buffer, end=2)
         # separate readinto because the SCD30 wants an i2c stop before the read (non-repeated start)
+        time.sleep(0.005)  # min 3 ms delay
         with self.i2c_device as i2c:
             i2c.readinto(self._buffer, end=2)
         return unpack_from(">H", self._buffer)[0]

--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -278,7 +278,7 @@ class SCD30:
 
         with self.i2c_device as i2c:
             i2c.write(self._buffer, end=end_byte)
-        time.sleep(0.05) # 3ms min delay
+        time.sleep(0.05)  # 3ms min delay
 
     def _read_register(self, reg_addr):
         self._buffer[0] = reg_addr >> 8

--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -285,11 +285,12 @@ class SCD30:
         self._buffer[1] = reg_addr & 0xFF
         with self.i2c_device as i2c:
             i2c.write(self._buffer, end=2)
-        # separate readinto because the SCD30 wants an i2c stop before the read (non-repeated start)
-        time.sleep(0.005)  # min 3 ms delay
-        with self.i2c_device as i2c:
-            i2c.readinto(self._buffer, end=2)
-        return unpack_from(">H", self._buffer)[0]
+            # separate readinto because the SCD30 wants an i2c stop before the read (non-repeated start)
+            time.sleep(0.005)  # min 3 ms delay
+            i2c.readinto(self._buffer, end=3)
+        if not self._check_crc(self._buffer[:2], self._buffer[2]):
+            raise RuntimeError("CRC check failed while reading data")
+        return unpack_from(">H", self._buffer[0:2])[0]
 
     def _read_data(self):
         self._send_command(_CMD_READ_MEASUREMENT)

--- a/adafruit_scd30.py
+++ b/adafruit_scd30.py
@@ -285,7 +285,8 @@ class SCD30:
         self._buffer[1] = reg_addr & 0xFF
         with self.i2c_device as i2c:
             i2c.write(self._buffer, end=2)
-            # separate readinto because the SCD30 wants an i2c stop before the read (non-repeated start)
+            # separate readinto because the SCD30 wants an i2c stop before the read
+            # (non-repeated start)
             time.sleep(0.005)  # min 3 ms delay
             i2c.readinto(self._buffer, end=3)
         if not self._check_crc(self._buffer[:2], self._buffer[2]):

--- a/examples/scd30_ft232htest.py
+++ b/examples/scd30_ft232htest.py
@@ -6,9 +6,10 @@ import board
 import busio
 import adafruit_scd30
 
-# SCD-30 has tempremental I2C with clock stretching, datasheet recommends
-# starting at 50KHz
-i2c = busio.I2C(board.SCL, board.SDA, frequency=50000)
+# SCD-30 has tempremental I2C with clock stretching, and delays
+# It's best to start using I2C clock slower and then you can increase it
+# until the sensor stops responding (NAK fails, etc)
+i2c = busio.I2C(board.SCL, board.SDA, frequency=1000) # for FT232H, use 1KHz
 scd = adafruit_scd30.SCD30(i2c)
 
 while True:

--- a/examples/scd30_ft232htest.py
+++ b/examples/scd30_ft232htest.py
@@ -9,7 +9,7 @@ import adafruit_scd30
 # SCD-30 has tempremental I2C with clock stretching, and delays
 # It's best to start using I2C clock slower and then you can increase it
 # until the sensor stops responding (NAK fails, etc)
-i2c = busio.I2C(board.SCL, board.SDA, frequency=1000) # for FT232H, use 1KHz
+i2c = busio.I2C(board.SCL, board.SDA, frequency=1000)  # for FT232H, use 1KHz
 scd = adafruit_scd30.SCD30(i2c)
 
 while True:

--- a/examples/scd30_mcp2221test.py
+++ b/examples/scd30_mcp2221test.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Unlicense
 import time
 import board
+import busio
 import adafruit_scd30
 
-i2c = board.I2C()  # uses board.SCL and board.SDA
+# SCD-30 has tempremental I2C with clock stretching, datasheet recommends
+# starting at 50KHz
+i2c = busio.I2C(board.SCL, board.SDA, frequency=50000)
 scd = adafruit_scd30.SCD30(i2c)
 
 # The SCD30 reset generates a hiccup on the SCL and SDA lines

--- a/examples/scd30_simpletest.py
+++ b/examples/scd30_simpletest.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Unlicense
 import time
 import board
-import adafruit_scd30
 import busio
+import adafruit_scd30
 
 # SCD-30 has tempremental I2C with clock stretching, and delays
 # It's best to start using I2C clock 1000 Hz and then you can increase it

--- a/examples/scd30_simpletest.py
+++ b/examples/scd30_simpletest.py
@@ -7,9 +7,10 @@ import busio
 import adafruit_scd30
 
 # SCD-30 has tempremental I2C with clock stretching, and delays
-# It's best to start using I2C clock 1000 Hz and then you can increase it
+# It's best to start using I2C clock slower and then you can increase it
 # until the sensor stops responding (NAK fails, etc)
-i2c = busio.I2C(board.SCL, board.SDA, frequency=1000)
+#i2c = busio.I2C(board.SCL, board.SDA, frequency=1000) # for FT232H, use 1KHz
+i2c = busio.I2C(board.SCL, board.SDA, frequency=50000) # for MCP2221 and others, use 50KHz
 scd = adafruit_scd30.SCD30(i2c)
 
 while True:

--- a/examples/scd30_simpletest.py
+++ b/examples/scd30_simpletest.py
@@ -4,8 +4,12 @@
 import time
 import board
 import adafruit_scd30
+import busio
 
-i2c = board.I2C()  # uses board.SCL and board.SDA
+# SCD-30 has tempremental I2C with clock stretching, and delays
+# It's best to start using I2C clock 1000 Hz and then you can increase it
+# until the sensor stops responding (NAK fails, etc)
+i2c = busio.I2C(board.SCL, board.SDA, frequency=1000)
 scd = adafruit_scd30.SCD30(i2c)
 
 while True:
@@ -13,9 +17,9 @@ while True:
     # the values, to ensure current readings.
     if scd.data_available:
         print("Data Available!")
-        print("CO2:", scd.CO2, "PPM")
-        print("Temperature:", scd.temperature, "degrees C")
-        print("Humidity:", scd.relative_humidity, "%%rH")
+        print("CO2: %d PPM" % scd.CO2)
+        print("Temperature: %0.2f degrees C" % scd.temperature)
+        print("Humidity: %0.2f %% rH" % scd.relative_humidity)
         print("")
         print("Waiting for new data...")
         print("")

--- a/examples/scd30_tuning_knobs.py
+++ b/examples/scd30_tuning_knobs.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Unlicense
 import time
 import board
+import busio
 import adafruit_scd30
 
-i2c = board.I2C()  # uses board.SCL and board.SDA
+# SCD-30 has tempremental I2C with clock stretching, datasheet recommends
+# starting at 50KHz
+i2c = busio.I2C(board.SCL, board.SDA, frequency=50000)
 scd = adafruit_scd30.SCD30(i2c)
 # scd.temperature_offset = 10
 print("Temperature offset:", scd.temperature_offset)


### PR DESCRIPTION
clean example
slow down i2c default for finicky controllers
crc check register read

fixes https://github.com/adafruit/Adafruit_CircuitPython_SCD30/issues/18
resolves https://github.com/adafruit/Adafruit_CircuitPython_SCD30/issues/13 (even tho it doesnt matter)
