### PR TITLE
Use slower I2C clock in README.rst as per e7d04a6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,9 @@ Usage Example
     import board
     import adafruit_scd30
 
-    i2c = board.I2C()   # uses board.SCL and board.SDA
+    # SCD-30 has tempremental I2C with clock stretching, datasheet recommends
+    # starting at 50KHz
+    i2c = busio.I2C(board.SCL, board.SDA,frequency=50000)
     scd = adafruit_scd30.SCD30(i2c)
 
     while True:


### PR DESCRIPTION
I had previously used the example in README.rst without this, and had reads fail after a few hours of use (updating every 2 seconds as default).